### PR TITLE
Disable edit button if ReferenceValue or NodeFunctionIdWrapper is used.

### DIFF
--- a/src/packages/ce/src/datatype/components/inputs/json/DataTypeJSONInputComponent.tsx
+++ b/src/packages/ce/src/datatype/components/inputs/json/DataTypeJSONInputComponent.tsx
@@ -124,7 +124,10 @@ export const DataTypeJSONInputComponent: React.FC<DataTypeJSONInputComponentProp
                                                                                  onClick={() => setEditDialogOpen(true)}>
                                                              <IconAlignLeft size={13}/>
                                                          </Button>}/>
-                        <Button paddingSize="xxs" variant="filled" color="secondary"
+                        <Button paddingSize="xxs"
+                                variant="filled"
+                                disabled={value?.__typename != "LiteralValue"}
+                                color="secondary"
                                 onClick={() => setEditDialogOpen(true)}>
                             <IconEdit size={13}/>
                         </Button>


### PR DESCRIPTION
Close #155 