### PR TITLE
Node selection from ReactFlow is enabled when creating a screenshot

### DIFF
--- a/src/packages/ce/src/flow/components/builder/FlowBuilderComponent.tsx
+++ b/src/packages/ce/src/flow/components/builder/FlowBuilderComponent.tsx
@@ -751,6 +751,7 @@ const InternalFlowBuilder: React.FC<FlowBuilderProps> = (props) => {
             nodes={nodes}
             edges={edges}
             panOnDrag={showTree}
+            selectionKeyCode={null}
             zoomOnScroll={showTree}
             zoomOnPinch={showTree}
             zoomOnDoubleClick={showTree}


### PR DESCRIPTION
Close #154 